### PR TITLE
Cleanup SSL implementation

### DIFF
--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,2 +1,3 @@
 configure_file(server.conf ${CMAKE_BINARY_DIR}/conf/server.conf)
+configure_file(server_ssl_ctx.cfg ${CMAKE_BINARY_DIR}/conf/server_ssl_ctx.cfg)
 configure_file(staticFiles.conf ${CMAKE_BINARY_DIR}/conf/staticFiles.conf)

--- a/conf/server.conf
+++ b/conf/server.conf
@@ -20,22 +20,12 @@ https {
     enabled false
     port 8443 ; HTTPS Port
 
-    certificate "server.crt"
-    privateKey "server.key"
+    ssl {
+        ; Set the server context method, you can choose between TLS or DTLS
+        ctx_method "TLS"
 
-    ; ciphers list taken from https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
-    ; If the server fails to do the handshake, most probably is bacause of this list
-    ciphers "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS"
-
-    honorCipherOrder true
-    compression false ; Check https://en.wikipedia.org/wiki/CRIME before enable it
-
-    protocols {
-        ; Here you can disable outdated SSL/TLS protocols
-        SSL_OP_NO_SSLv2   true ; Do not use the SSLv2 protocol (default from OpenSSL 1.0.2g)
-        SSL_OP_NO_SSLv3   true ; Do not use the SSLv3 protocol (recommended)
-        SSL_OP_NO_TLSv1   flase ; Use the TLSv1.0 protocol.
-        SSL_OP_NO_TLSv1_1 false ; Use the TLSv1.1 protocol.
-        SSL_OP_NO_TLSv1_2 false ; Use the TLSv1.2 protocol.
+        ; The server context conf file, this file is a very flexible and powerful way
+        ; to set the server context properties from outside.
+        ctx_conf_file "server_ssl_ctx.cfg";
     }
 }

--- a/conf/server.conf
+++ b/conf/server.conf
@@ -13,7 +13,7 @@ privileges {
 ;    group "daemon" ; optinally the group that the server will use after it binds the ports.
                     ; If not specified the main group of the user will be used.
 
-; BE AWARE! The command line arguments takes precedent to the config file !
+; BE AWARE! The command line arguments takes precedence to the config file !
 }
 
 https {

--- a/conf/server_ssl_ctx.cfg
+++ b/conf/server_ssl_ctx.cfg
@@ -1,0 +1,57 @@
+
+;    SSL CTX Server configuration file
+
+; This file is a simple list of SSL key and optionally value commands.
+; The value(s) areadded without double or single quote.
+
+; For a full list of commands check:
+; https://www.openssl.org/docs/man1.1.1/man3/SSL_CONF_cmd.html "SUPPORTED CONFIGURATION FILE COMMANDS" section
+
+; Lines that starts with a semicolon (;) are ignorder and can be used to add comments
+
+
+; Attempts to load the file *server.crt* using SSL_CTX_use_certificate_chain_file as the certificate for the server context.
+Certificate server.crt
+
+
+; Attempts to load the file *server.key* as the private key for the server context.
+PrivateKey server.key
+
+
+; Set minimum supported protocol
+MinProtocol TLSv1.2
+
+
+; Set the ciphersuite list for TLSv1.2 and below to value. This list will be combined with any configured
+; TLSv1.3 ciphersuites.
+CipherString ECDH+AESGCM:ECDH+CHACHA20:ECDH+AES256:ECDH+AES128:!aNULL:!SHA1
+; the previous ciphers list was taken from https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+
+
+; Sets the available ciphersuites for TLSv1.3 to value. This is a simple colon (":") separated list of
+; TLSv1.3 ciphersuite names in order of preference. This list will be combined any configured TLSv1.2 and below ciphersuites.
+; See https://www.openssl.org/docs/man1.1.1/man1/ciphers.html for more information.
+; Ciphersuites
+
+; !!! WARNING: If the server fails to do the handshake, most probably is because of CipherString or Ciphersuites
+
+
+
+; Options section
+; The value argument is a comma separated list of various flags to set.
+; If a flag string is preceded - it is disabled.
+; See the https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_options.html for more details of individual options.
+
+
+; Disable compression
+Options -Compression
+
+; Use server and not client preference order when determining which cipher suite,
+; signature algorithm or elliptic curve to use for an incoming connection.
+Options ServerPreference
+
+; Disables all attempts at renegotiation in TLSv1.2 and earlier,
+Options NoRenegotiation
+
+; Other options
+Options NoResumptionOnRenegotiation,AntiReplay

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Boost 1.57 REQUIRED COMPONENTS coroutine program_options filesystem system)
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL 1.1 REQUIRED)
 
 include_directories(${PROJECT_SOURCE_DIR}/include http-parser ${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
 

--- a/src/server/secured_server_session.cpp
+++ b/src/server/secured_server_session.cpp
@@ -28,9 +28,6 @@ SecuredServerSession::SecuredServerSession(SessionsEventLoop *eventLoop, int soc
     if (!SSL_set_fd(m_SSL, sock))
         throw std::runtime_error(ERR_error_string(SSL_get_error(m_SSL, 0), nullptr));
 
-    if (!SSL_set_ex_data(m_SSL, Server::SSLDataIndex, this))
-        throw std::runtime_error(ERR_error_string(SSL_get_error(m_SSL, 0), nullptr));
-
     SSL_set_accept_state(m_SSL);
 }
 
@@ -99,10 +96,6 @@ void SecuredServerSession::messageComplete()
         }
         return;
     }
-
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL
-    SSL_set_state(m_SSL, SSL_ST_ACCEPT);
-#endif
 
     step = 0;
     while ( (ret = SSL_do_handshake(m_SSL)) != 1) {

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -51,7 +51,6 @@ public:
     inline void sessionServed() { ++m_servedSessions; }
     uint64_t servedSessions() const { return m_servedSessions; }
     SSL_CTX *sslContext() const;
-    static int SSLDataIndex;
 
 private:
     Server();


### PR DESCRIPTION
Add server_ssl_ctx.cfg file as a much more powerful and flexible way to
setup the server ssl context.

Close #13 