### PR TITLE
Move logging setup after we set the new gid/uid

### DIFF
--- a/conf/server_logging.conf
+++ b/conf/server_logging.conf
@@ -1,3 +1,6 @@
+; Check https://www.boost.org/doc/libs/1_67_0/libs/log/doc/html/log/detailed/utilities.html#log.detailed.utilities.setup.settings
+; for more info
+
 Core {
     ; There are 6 logging levels :
     ; trace     - the most verbose, it prints tons of info useful to catch any problem
@@ -28,8 +31,9 @@ Sinks {
 ;        Asynchronous true
 ;        Destination TextFile
 ;        Target "/var/log"
-;        FileName "GETodac_%3N.log"
+;        FileName "/var/log/GETodac_%3N.log"
 ;        AutoFlush true
+;        ScanForFiles "Matching"
 ;        RotationSize 10485760 ; 10 MiB
 ;        Format "<%Severity%> %TimeStamp%:%Tag% %Message%"
 ;        Filter "%Severity% >= info"


### PR DESCRIPTION
This change is needed to make sure the logs are written using the new
gid/uid.